### PR TITLE
RC0075 - Integrate labelling with evaluation framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,34 +5,24 @@ Annotate videos in common formats(mp4, avi, mkv, wav, mp3)
 
 The table in the exercise video annotator is used to input and store the labels for each exercise. The data in the table can be exported and imported into a CSV File.  The data is then transformed before exporting, converting the times to frame number and generate unique labels for each exercise.
 
-![example](https://github.com/atlas-fitness/exercise_video_annotator/blob/mo/EVAL0011/Examples/example.png)
+![example](Examples/example.png)
 
 ## Installation
  ### Windows
- Run [Required software for Windows/K-Lite_Codec_Pack_1532_Basic.exe](https://github.com/dyfanmo/exercise_video_annotator/blob/main/Required%20software%20for%20Windows/K-Lite_Codec_Pack_1532_Basic.exe) file to support video
+ Run [Required software for Windows/K-Lite_Codec_Pack_1532_Basic.exe](Required%20software%20for%20Windows/K-Lite_Codec_Pack_1532_Basic.exe) file to support video
   ```
-     pip install numpy
-     pip install PyQt5
-    
+     pip install -r requirements    
 ```
 
-
- ### Linux/Ubuntu
+ ### Linux/Ubuntu/MacOS
   ```
-     pip install numpy
-     sudo apt-get install python3-pyqt5
-```
- ### MacOs
-   ```
-     pip install numpy
-     brew install pyqt
+     pip install -r requirements    
 ```
  
 ## Usage
    * Running the annotator
  ```
      python pavs.py
-
 ```
 
 ## Shortcuts

--- a/pavs.py
+++ b/pavs.py
@@ -51,6 +51,7 @@ from utils import (
     get_labels_from_api,
     get_video_fps,
     convert_frame_num_to_time,
+    upload_file_to_s3,
 )
 
 from atlas_utils.evaluation_framework.generate_report import generate_report
@@ -618,10 +619,11 @@ class Window(QMainWindow):
             # generate report locally
             pdf_fp = generate_report(self.tmpDir, str(self.videoResultId), output_pdf_dir=self.tmpDir)
             # upload report to S3
-            print(f"Report at: {pdf_fp}")
-
+            upload_file_to_s3(self.userId, self.videoResultId, pdf_fp)
+            showDialog(f"Report generated at: {pdf_fp} and uploaded to S3!")
         except Exception as e:
             print(f"ERROR: {e}")
+            showDialog(str(e), success=False)
         finally:
             self.reportButton.setDisabled(False)
 

--- a/pavs.py
+++ b/pavs.py
@@ -156,17 +156,10 @@ class Window(QMainWindow):
         super().__init__()
 
         self.title = "Exercise Video Annotator"
-        # self.top = 100
-        # self.left = 100
-        # self.width = 300
-        # self.height = 400
-        # self.setWindowState = "Qt.WindowMaximized"
-        iconName = "home.png"
         self.InitWindow()
 
     def InitWindow(self):
         self.setWindowTitle(self.title)
-        # self.setWindowIcon(QtGui.QIcon(iconName))
         self.setWindowState(QtCore.Qt.WindowMaximized)
 
         self.UiComponents()
@@ -204,12 +197,10 @@ class Window(QMainWindow):
         self.lbl = QLabel("00:00:00")
         self.lbl.setFixedWidth(60)
         self.lbl.setUpdatesEnabled(True)
-        # self.lbl.setStyleSheet(stylesheet(self))
 
         self.elbl = QLabel("00:00:00")
         self.elbl.setFixedWidth(60)
         self.elbl.setUpdatesEnabled(True)
-        # self.elbl.setStyleSheet(stylesheet(self))
 
         self.playbackIndicator = QLabel("X" + str(self.mediaPlayer.playbackRate()))
         self.playbackIndicator.setFixedWidth(60)
@@ -229,9 +220,6 @@ class Window(QMainWindow):
 
         self.importButton = QPushButton("Import")
         self.importButton.clicked.connect(self.importCSV)
-
-        # self.ctr = QLineEdit()
-        # self.ctr.setPlaceholderText("Extra")
 
         self.startTime = QLineEdit()
         self.startTime.setPlaceholderText("Start Time")
@@ -268,9 +256,6 @@ class Window(QMainWindow):
         self.orientation.addItem("diagonal")
         self.orientation.activated[str].connect(self.style_choice)
 
-        # self.iLabel = QLineEdit()
-        # self.iLabel.setPlaceholderText("Label")
-
         self.positionSlider = QSlider(Qt.Horizontal)
         self.positionSlider.setRange(0, 100)
         self.positionSlider.sliderMoved.connect(self.setPosition)
@@ -286,7 +271,6 @@ class Window(QMainWindow):
         plotBox = QHBoxLayout()
 
         controlLayout = QHBoxLayout()
-        # controlLayout.setContentsMargins(0, 0, 0, 0)
         controlLayout.addWidget(openButton)
         controlLayout.addWidget(self.playButton)
         controlLayout.addWidget(self.lbl)
@@ -298,11 +282,8 @@ class Window(QMainWindow):
         self.setCentralWidget(wid)
 
         # Left Layout{
-        # layout.addWidget(self.videoWidget)
-
         layout = QVBoxLayout()
         layout.addWidget(self.videoWidget, 1)
-        # layout.addLayout(self.grid_root)
         layout.addLayout(controlLayout)
         layout.addWidget(self.errorLabel)
 
@@ -320,8 +301,6 @@ class Window(QMainWindow):
         inputFields.addWidget(self.rules, 1)
         inputFields.addWidget(self.repsToJudge, 1)
 
-        # inputFields.addWidget(self.ctr)
-
         feats = QHBoxLayout()
         feats.addWidget(self.nextButton)
         feats.addWidget(self.delButton)
@@ -333,12 +312,10 @@ class Window(QMainWindow):
         layout2.addWidget(self.tableWidget)
         layout2.addLayout(inputFields, 1)
         layout2.addLayout(feats, 2)
-        # layout2.addWidget(self.nextButton)
         # }
 
         plotBox.addLayout(layout2, 2)
 
-        # self.setLayout(layout)
         wid.setLayout(plotBox)
 
         self.shortcut = QShortcut(QKeySequence("["), self)
@@ -397,13 +374,10 @@ class Window(QMainWindow):
             self.playButton.setEnabled(True)
 
     def play(self):
-        # self.is_playing_video = not self.is_playing_video
         if self.mediaPlayer.state() == QMediaPlayer.PlayingState:
             self.mediaPlayer.pause()
         else:
             self.mediaPlayer.play()
-            # self._play_video()
-            # self.errorLabel.setText("Start: " + " -- " + " End:")
 
     def _play_video(self):
         if self.is_playing_video and self.video_fps:
@@ -447,11 +421,7 @@ class Window(QMainWindow):
         self.colNo = 0
         self.rowNo += 1
 
-        # print(self.ctr.text(), self.startTime.text(), self.iLabel.text(), self.rowNo, self.colNo)
-        # print(self.iLabel.currentIndex())
-
     def delete(self):
-        # print("delete")
         index_list = []
         for model_index in self.tableWidget.selectionModel().selectedRows():
             index = QtCore.QPersistentModelIndex(model_index)
@@ -556,9 +526,6 @@ class Window(QMainWindow):
             with open(path, "r") as stream:
                 print("loading", path)
                 reader = csv.reader(stream)
-                # reader = csv.reader(stream, delimiter=';', quoting=csv.QUOTE_ALL)
-                # reader = csv.reader(stream, delimiter=';', quoting=csv.QUOTE_ALL)
-                # for row in reader:
                 for i, row in enumerate(reader):
                     if i == 0:
                         continue
@@ -601,7 +568,6 @@ class Window(QMainWindow):
 
     def checkTableFrame(self, row, column):
         if (row > 0) and (column < 2):
-            # print("Row %d and Column %d was clicked" % (row, column))
             item = self.tableWidget.item(row, column)
             if item != (None and ""):
                 try:
@@ -610,9 +576,6 @@ class Window(QMainWindow):
                     frameTime = int(itemFrame[2]) + int(itemFrame[1]) * 60 + int(itemFrame[0]) * 3600
                     elblFrames = self.elbl.text().split(":")
                     elblFrameTime = int(elblFrames[2]) + int(elblFrames[1]) * 60 + int(elblFrames[0]) * 3600
-                    # print("Elbl FT ", str(elblFrameTime))
-                    # print("FT ", str(frameTime))
-                    # print(frameTime)
                     self.mediaPlayer.setPosition(frameTime * 1000 + 1 * 60)
                 except:
                     self.errorLabel.setText("Some Video Error - Please Recheck Video Imported!")
@@ -660,12 +623,6 @@ class Window(QMainWindow):
     def volumeDown(self):
         self.mediaPlayer.setVolume(self.mediaPlayer.volume() - 10)
         print("Volume: " + str(self.mediaPlayer.volume()))
-
-    # def mouseMoveEvent(self, event):
-    # if event.buttons() == Qt.LeftButton:
-    #     self.move(event.globalPos() \- QPoint(self.frameGeometry().width() / 2, \
-    #                 self.frameGeometry().height() / 2))
-    #     event.accept()
 
     def dragEnterEvent(self, event):
         if event.mimeData().hasUrls():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+ssh://git@github.com/atlas-fitness/atlas_utils.git@develop
 pandas
 numpy
-PyQt5
+PyQt5==5.10
 opencv-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 git+ssh://git@github.com/atlas-fitness/atlas_utils.git@develop
+pandas
 numpy
 PyQt5
 opencv-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+git+ssh://git@github.com/atlas-fitness/atlas_utils.git@develop
 numpy
 PyQt5
 opencv-python

--- a/utils.py
+++ b/utils.py
@@ -7,7 +7,7 @@ import string
 import random
 import tempfile
 
-from atlas_utils.aws_utils import aws_download_file
+from atlas_utils.aws_utils import aws_download_file, aws_upload_file
 
 
 def convert_time_to_seconds(time_string):
@@ -149,13 +149,20 @@ def send_labels_to_api(user_id, video_result_id, labels_df):
 
 
 def download_file_from_s3(user_id, video_result_id, filename, local_fp=""):
-    """Download video from S3 and put it in tmp dir. Returns filepath to local video"""
+    """Download file from S3 and put it in tmp dir. Returns filepath to local file"""
     aws_fp = f"{user_id}/{video_result_id}/{filename}"
     bucket = "atlas-remote-internal"
     if local_fp == "":
         local_fp = os.path.join(tempfile.gettempdir(), filename)
     aws_download_file(aws_fp, local_fp=local_fp, bucket=bucket)
     return local_fp
+
+
+def upload_file_to_s3(user_id, video_result_id, filename):
+    """Upload file to S3"""
+    object_name = f"{user_id}/{video_result_id}/{os.path.basename(filename)}"
+    bucket = "atlas-remote-internal"
+    aws_upload_file(filename, bucket=bucket, object_name=object_name)
 
 
 def get_labels_from_api(user_id, video_result_id):

--- a/utils.py
+++ b/utils.py
@@ -148,11 +148,12 @@ def send_labels_to_api(user_id, video_result_id, labels_df):
     return "\n\n".join(errors)
 
 
-def download_video_from_s3(user_id, video_result_id):
+def download_file_from_s3(user_id, video_result_id, filename, local_fp=""):
     """Download video from S3 and put it in tmp dir. Returns filepath to local video"""
-    aws_fp = f"{user_id}/{video_result_id}/full_video.ts"
+    aws_fp = f"{user_id}/{video_result_id}/{filename}"
     bucket = "atlas-remote-internal"
-    local_fp = os.path.join(tempfile.gettempdir(), "atlas_labelling_full_video.ts")
+    if local_fp == "":
+        local_fp = os.path.join(tempfile.gettempdir(), filename)
     aws_download_file(aws_fp, local_fp=local_fp, bucket=bucket)
     return local_fp
 

--- a/utils.py
+++ b/utils.py
@@ -5,6 +5,9 @@ import pandas as pd
 import requests
 import string
 import random
+import tempfile
+
+from atlas_utils.aws_utils import aws_download_file
 
 
 def convert_time_to_seconds(time_string):
@@ -128,3 +131,12 @@ def send_labels_to_api(user_id, video_result_id, override, labels_df):
                 errors.append(f"Failed to create label {name} with error: {response.json()['errors']['name']}")
     # return errors to display to user
     return "\n\n".join(errors)
+
+
+def download_video_from_s3(user_id, video_result_id):
+    """Download video from S3 and put it in tmp dir. Returns filepath to local video"""
+    aws_fp = f"{user_id}/{video_result_id}/full_video.ts"
+    bucket = "atlas-remote-internal"
+    local_fp = os.path.join(tempfile.gettempdir(), "atlas_labelling_full_video.ts")
+    aws_download_file(aws_fp, local_fp=local_fp, bucket=bucket)
+    return local_fp


### PR DESCRIPTION
We have the video labels stored in the DB, so now we can use them inside the evaluation framework instead of using csv files. They are currently used in `generate_report.py`

As part of this, we want to do a couple of QoL changes to the labelling tool and process. Ideally we want to download the video, label it and generate a report all from one place. 

Additions:
- load video from S3
- load labels from DB
- save labels to DB
- generate report
- upload report to S3