### PR TITLE
EVAL0043 - Link the form error drop-down to the exercise dropdown

### DIFF
--- a/config/rules.txt
+++ b/config/rules.txt
@@ -1,9 +1,0 @@
-knee_track
-depth
-range_of_motion
-step_width
-hip_shift
-heel_lift
-head_stability
-elbow_angle
-N/A

--- a/pavs.py
+++ b/pavs.py
@@ -46,13 +46,13 @@ from utils import (
     add_is_valid_column_values,
 )
 
+from atlas_utils.evaluation_framework.report_generation.form_error.calculate_form_error import form_threshold_dict
 from atlas_utils.evaluation_framework.generate_report import generate_report
 from atlas_utils.vid_utils import vid_to_frames
 
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--classes_label_path", type=str, default="config/classes.txt")
-parser.add_argument("--rules_path", type=str, default="config/rules.txt")
 args = parser.parse_args()
 
 audio_extensions = [".wav", ".mp3"]
@@ -250,18 +250,15 @@ class Window(QMainWindow):
             self.iLabel.addItem(exercise_class[0].strip())
         self.iLabel.activated[str].connect(self.style_choice)
 
-        self.rules = QComboBox(self)
-        rules_file = open(args.rules_path, "r")
-        rules_list = [line.split(",") for line in rules_file.readlines()]
-        for rule in rules_list:
-            self.rules.addItem(rule[0].strip())
-        self.rules.activated[str].connect(self.style_choice)
-
         self.orientation = QComboBox(self)
         self.orientation.addItem("front")
         self.orientation.addItem("side")
         self.orientation.addItem("diagonal")
         self.orientation.activated[str].connect(self.style_choice)
+
+        self.rules = QComboBox(self)
+        self.iLabel.currentIndexChanged.connect(self.update_rules)
+        self.orientation.currentIndexChanged.connect(self.update_rules)
 
         self.isValid = QComboBox(self)
         self.isValid.addItem("N/A")
@@ -714,6 +711,19 @@ class Window(QMainWindow):
     def update_playback_label(self):
         self.playbackIndicator.clear()
         self.playbackIndicator.setText("X" + str(self.mediaPlayer.playbackRate()))
+
+    def update_rules(self):
+        exercise, orientation = self.iLabel.currentText().strip(), self.orientation.currentText().strip()
+
+        self.rules.clear()
+
+        if exercise in form_threshold_dict and orientation in form_threshold_dict[exercise]:
+            rules_list = list(form_threshold_dict[exercise][orientation].keys())
+            for rule in rules_list:
+                self.rules.addItem(rule.strip())
+
+        self.rules.addItem("N/A")
+        self.rules.activated[str].connect(self.style_choice)
 
 
 App = QApplication(sys.argv)


### PR DESCRIPTION
## Tasks <!-- The tasks this PR addresses  -->
EVAL0043 - Link the form error drop-down to the exercise drop-down

## Symptoms <!-- How does the problem manifest itself? (from the user's perspective) -->
The user accidental selects a form error that is not associated with the exercise and orientation. 

## Problems <!-- What are the underlying problems that cause these symptoms, and why? -->
The labelling tool does not reduce the chances of human error when selecting the form error.

## Solution <!-- How did you solve the problems? Why did you solve them the way you did? -->
I built a function called update_rules() which can update the values in the form error drop-down.   The function is activated if the index in the exercise or orientation  drop-down changes. 

## Verification <!-- How did you test your solution? Specify any new or modified tests. -->
The script works