### PR TITLE
EVAL0052 - Option on video annotator to use text field input for exercises

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The table in the exercise video annotator is used to input and store the labels 
  ```
      python pavs.py
 ```
+   * You can use a list of preset exercises to choose from in the labelling tool. In this case use:
+   ```
+     python pavs.py --classes_label_path config/classes.txt
+```
 
 ## Shortcuts
 - Load video: L

--- a/pavs.py
+++ b/pavs.py
@@ -54,7 +54,7 @@ from atlas_utils.tools import get_video_filename_from_api
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--classes_label_path", type=str, default="config/classes.txt")
+    parser.add_argument("--classes_label_path", type=str)
     args = parser.parse_args()
 
     App = QApplication(sys.argv)
@@ -248,22 +248,29 @@ class Window(QMainWindow):
         self.repsToJudge = QLineEdit()
         self.repsToJudge.setPlaceholderText("Reps To Judge")
 
-        self.iLabel = QComboBox(self)
-        exercise_file = open(classes_label_path, "r")
-        exercise_list = [line.split(",") for line in exercise_file.readlines()]
-        for exercise_class in exercise_list:
-            self.iLabel.addItem(exercise_class[0].strip())
-        self.iLabel.activated[str].connect(self.style_choice)
-
         self.orientation = QComboBox(self)
         self.orientation.addItem("front")
         self.orientation.addItem("side")
         self.orientation.addItem("diagonal")
         self.orientation.activated[str].connect(self.style_choice)
 
-        self.rules = QComboBox(self)
-        self.iLabel.currentIndexChanged.connect(self.update_rules)
-        self.orientation.currentIndexChanged.connect(self.update_rules)
+        if classes_label_path:
+            self.iLabel = QComboBox(self)
+            exercise_file = open(classes_label_path, "r")
+            exercise_list = [line.split(",") for line in exercise_file.readlines()]
+            for exercise_class in exercise_list:
+                self.iLabel.addItem(exercise_class[0].strip())
+            self.iLabel.activated[str].connect(self.style_choice)
+
+            self.rules = QComboBox(self)
+            self.iLabel.currentIndexChanged.connect(self.update_rules)
+            self.orientation.currentIndexChanged.connect(self.update_rules)
+        else:
+            self.iLabel = QLineEdit()
+            self.iLabel.setPlaceholderText("Exercise")
+
+            self.rules = QLineEdit()
+            self.rules.setPlaceholderText("Rule")
 
         self.isValid = QComboBox(self)
         self.isValid.addItem("N/A")


### PR DESCRIPTION
## Tasks <!-- The tasks this PR addresses  -->
Option on video annotator to use text field input for exercises

## Symptoms <!-- How does the problem manifest itself? (from the user's perspective) -->
The exercise dropdown bar will not include the new exercises.


## Problems <!-- What are the underlying problems that cause these symptoms, and why? -->
You do not know all the exercises that could happen in the new videos.


## Solution <!-- How did you solve the problems? Why did you solve them the way you did? -->
Use an input text field instead.


## Verification <!-- How did you test your solution? Specify any new or modified tests. -->
Script works

