### PR TITLE
EVAL0051 - Option to load in annotated video rather than raw

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The table in the exercise video annotator is used to input and store the labels 
  ```
      python pavs.py
 ```
+   * You can use a list of preset exercises to choose from in the labelling tool. In this case use:
+   ```
+     python pavs.py --classes_label_path config/classes.txt
+```
 
 ## Shortcuts
 - Load video: L

--- a/pavs.py
+++ b/pavs.py
@@ -55,7 +55,7 @@ from atlas_utils.tools import get_video_filename_from_api
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--classes_label_path", type=str, default="config/classes.txt")
+    parser.add_argument("--classes_label_path", type=str)
     args = parser.parse_args()
 
     App = QApplication(sys.argv)
@@ -127,9 +127,9 @@ class OpenVideoInputDialog(QDialog):
 
         self.userId = QLineEdit(self)
         self.videoResultId = QLineEdit(self)
+        self.annotated_video_radio_button = QRadioButton("Annotated Video", self)
+        self.full_video_radio_button = QRadioButton("Full Video", self)
         self.videoFilepath = ""
-        self.b1 = QRadioButton("Annotated Video", self)
-        self.b2 = QRadioButton("Full Video", self)
         buttonBox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, self)
         openButton = QPushButton("Choose...")
         openButton.clicked.connect(self.openFile)
@@ -142,8 +142,8 @@ class OpenVideoInputDialog(QDialog):
         layout.addRow(QLabel("From S3 bucket"))
         layout.addRow("User ID", self.userId)
         layout.addRow("Video Result ID", self.videoResultId)
-        layout.addWidget(self.b1)
-        layout.addWidget(self.b2)
+        layout.addWidget(self.annotated_video_radio_button)
+        layout.addWidget(self.full_video_radio_button)
         layout.addWidget(buttonBox)
         layout.addRow(QLabel("From local files"))
         layout.addWidget(openButton)
@@ -152,7 +152,13 @@ class OpenVideoInputDialog(QDialog):
         buttonBox.rejected.connect(self.reject)
 
     def getInputs(self):
-        return (self.userId.text(), self.videoResultId.text(), self.videoFilepath, self.b1, self.b2)
+        return (
+            self.userId.text(),
+            self.videoResultId.text(),
+            self.videoFilepath,
+            self.annotated_video_radio_button,
+            self.full_video_radio_button,
+        )
 
     def openFile(self):
         fileName, _ = QFileDialog.getOpenFileName(self, "Open Movie", QDir.homePath())
@@ -253,22 +259,29 @@ class Window(QMainWindow):
         self.repsToJudge = QLineEdit()
         self.repsToJudge.setPlaceholderText("Reps To Judge")
 
-        self.iLabel = QComboBox(self)
-        exercise_file = open(classes_label_path, "r")
-        exercise_list = [line.split(",") for line in exercise_file.readlines()]
-        for exercise_class in exercise_list:
-            self.iLabel.addItem(exercise_class[0].strip())
-        self.iLabel.activated[str].connect(self.style_choice)
-
         self.orientation = QComboBox(self)
         self.orientation.addItem("front")
         self.orientation.addItem("side")
         self.orientation.addItem("diagonal")
         self.orientation.activated[str].connect(self.style_choice)
 
-        self.rules = QComboBox(self)
-        self.iLabel.currentIndexChanged.connect(self.update_rules)
-        self.orientation.currentIndexChanged.connect(self.update_rules)
+        if classes_label_path:
+            self.iLabel = QComboBox(self)
+            exercise_file = open(classes_label_path, "r")
+            exercise_list = [line.split(",") for line in exercise_file.readlines()]
+            for exercise_class in exercise_list:
+                self.iLabel.addItem(exercise_class[0].strip())
+            self.iLabel.activated[str].connect(self.style_choice)
+
+            self.rules = QComboBox(self)
+            self.iLabel.currentIndexChanged.connect(self.update_rules)
+            self.orientation.currentIndexChanged.connect(self.update_rules)
+        else:
+            self.iLabel = QLineEdit()
+            self.iLabel.setPlaceholderText("Exercise")
+
+            self.rules = QLineEdit()
+            self.rules.setPlaceholderText("Rule")
 
         self.isValid = QComboBox(self)
         self.isValid.addItem("N/A")
@@ -383,8 +396,13 @@ class Window(QMainWindow):
     def openFile(self):
         openVideoDialog = OpenVideoInputDialog(self)
         if openVideoDialog.exec():
-            user_id, video_result_id, video_filepath, b1, b2 = openVideoDialog.getInputs()
-            b1_is_checked, b2_is_checked = b1.isChecked(), b2.isChecked()
+            (
+                user_id,
+                video_result_id,
+                video_filepath,
+                annotated_video_radio_button,
+                full_video_radio_button,
+            ) = openVideoDialog.getInputs()
 
             self.userId = int(user_id) if user_id != "" else -1
             self.videoResultId = int(video_result_id) if video_result_id != "" else -1
@@ -392,12 +410,10 @@ class Window(QMainWindow):
 
             if self.video_file_path == "":
                 try:
-                    if b1_is_checked:
-                        filename = "annotated_video.mp4"
-                    elif b2_is_checked:
+                    if full_video_radio_button.isChecked():
                         filename = get_video_filename_from_api(self.userId, self.videoResultId)
                     else:
-                        showErrorDialog("Choose which type of video to load.")
+                        filename = "annotated_video.mp4"
 
                     self.video_file_path = download_file_from_s3(self.userId, self.videoResultId, filename)
                     fps = get_video_fps(self.video_file_path)

--- a/pavs.py
+++ b/pavs.py
@@ -129,6 +129,7 @@ class OpenVideoInputDialog(QDialog):
         self.videoResultId = QLineEdit(self)
         self.annotated_video_radio_button = QRadioButton("Annotated Video", self)
         self.full_video_radio_button = QRadioButton("Full Video", self)
+        self.annotated_video_radio_button.setChecked(True)
         self.videoFilepath = ""
         buttonBox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, self)
         openButton = QPushButton("Choose...")
@@ -407,6 +408,7 @@ class Window(QMainWindow):
             self.userId = int(user_id) if user_id != "" else -1
             self.videoResultId = int(video_result_id) if video_result_id != "" else -1
             self.video_file_path = video_filepath
+            filename = ""
 
             if self.video_file_path == "":
                 try:

--- a/pavs.py
+++ b/pavs.py
@@ -414,7 +414,7 @@ class Window(QMainWindow):
                 try:
                     if full_video_radio_button.isChecked():
                         filename = get_video_filename_from_api(self.userId, self.videoResultId)
-                    else:
+                    elif annotated_video_radio_button.isChecked():
                         filename = "annotated_video.mp4"
 
                     self.video_file_path = download_file_from_s3(self.userId, self.videoResultId, filename)

--- a/pavs.py
+++ b/pavs.py
@@ -20,7 +20,6 @@ from PyQt5.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QMessageBox,
-    QCheckBox,
     QRadioButton,
 )
 from PyQt5.QtMultimedia import QMediaContent, QMediaPlayer
@@ -129,6 +128,8 @@ class OpenVideoInputDialog(QDialog):
         self.userId = QLineEdit(self)
         self.videoResultId = QLineEdit(self)
         self.videoFilepath = ""
+        self.b1 = QRadioButton("Annotated Video", self)
+        self.b2 = QRadioButton("Full Video", self)
         buttonBox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel, self)
         openButton = QPushButton("Choose...")
         openButton.clicked.connect(self.openFile)
@@ -141,14 +142,8 @@ class OpenVideoInputDialog(QDialog):
         layout.addRow(QLabel("From S3 bucket"))
         layout.addRow("User ID", self.userId)
         layout.addRow("Video Result ID", self.videoResultId)
-
-        self.b1 = QRadioButton("Annotated Video", self)
-
-        self.b2 = QRadioButton("Full Video", self)
-
         layout.addWidget(self.b1)
         layout.addWidget(self.b2)
-
         layout.addWidget(buttonBox)
         layout.addRow(QLabel("From local files"))
         layout.addWidget(openButton)


### PR DESCRIPTION
## Tasks <!-- The tasks this PR addresses  -->
Option to load in annotated video rather than raw

## Symptoms <!-- How does the problem manifest itself? (from the user's perspective) -->
You can not load the annotated video into the labelling.


## Problems <!-- What are the underlying problems that cause these symptoms, and why? -->
The labelling tool only loads the full video.


## Solution <!-- How did you solve the problems? Why did you solve them the way you did? -->
I added a checkbox to select which type of video to load.


## Verification <!-- How did you test your solution? Specify any new or modified tests. -->
Script works